### PR TITLE
Fix shell completion for storage: and file: schemes

### DIFF
--- a/neuro-cli/src/neuro_cli/click_types.py
+++ b/neuro-cli/src/neuro_cli/click_types.py
@@ -728,10 +728,10 @@ class PathURLCompleter(URLCompleter, abc.ABC):
         self._complete_dir = complete_dir
         self._complete_file = complete_file
 
-    def _get_dir_uri(self, uri: URL, incomplete: str) -> URL:
-        if incomplete.endswith("/"):
-            return uri / ""
-        return uri.parent / ""
+    def _split_uri(self, uri: URL, incomplete: str) -> Tuple[URL, str]:
+        if incomplete.endswith("/") or incomplete == uri.scheme + ":":
+            return uri, ""
+        return uri.parent, uri.name
 
     def _make_item(
         self,
@@ -744,7 +744,7 @@ class PathURLCompleter(URLCompleter, abc.ABC):
         return CompletionItem(
             name,
             type="uri",
-            prefix=str(parent) + "/" if parent.path else str(parent),
+            prefix=str(parent / ""),
         )
 
     @abc.abstractmethod
@@ -763,18 +763,18 @@ class PathURLCompleter(URLCompleter, abc.ABC):
         root: Root,
         incomplete: str,
     ) -> AsyncIterator[CompletionItem]:
-        dir_uri = self._get_dir_uri(uri, incomplete)
+        dir_uri, incomplete_name = self._split_uri(uri, incomplete)
         if not await self._is_valid_dir(root, dir_uri):
             return
         async with self._iter_dir(root, dir_uri) as it:
             async for item in it:
-                if str(dir_uri / item.name).startswith(incomplete):
+                if item.name.startswith(incomplete_name):
                     if item.is_dir() and not self._complete_dir:
                         continue
                     if not item.is_dir() and not self._complete_file:
                         continue
                     yield self._make_item(
-                        dir_uri.parent,
+                        dir_uri,
                         item.name,
                         item.is_dir(),
                     )
@@ -903,24 +903,25 @@ class PlatformURIType(AsyncType[URL]):
         else:
             return ret
 
+        if scheme != "file:" and incomplete == scheme + "//":
+            return _complete_clusters(root.client, incomplete, "")
+
         uri = root.client.parse.str_to_uri(
             incomplete,
             allowed_schemes=self._allowed_schemes,
-            short=not ("://" in incomplete),
+            short=not (
+                incomplete.startswith(scheme + "//")
+                and not incomplete.startswith(scheme + "///")
+            ),
         )
-        if uri.host and uri.path == "/" and not incomplete.endswith("/"):
+        if (
+            uri.scheme != "file"
+            and uri.host
+            and uri.path == "/"
+            and not incomplete.endswith("/")
+        ):
             # Cluster name is incomplete
-            for cluster_name in root.client.config.clusters:
-                if cluster_name.startswith(uri.host):
-                    ret.append(
-                        CompletionItem(
-                            f"{cluster_name}/", type="uri", prefix=f"{uri.scheme}://"
-                        )
-                    )
-            return ret
-        if uri.host and uri.path.count("/") == 1:
-            # Username completion not supported
-            return []
+            return _complete_clusters(root.client, f"{uri.scheme}://", uri.host)
         completer = self._completers.get(uri.scheme)
         if completer:
             return [

--- a/neuro-cli/tests/unit/test_shell_completion.py
+++ b/neuro-cli/tests/unit/test_shell_completion.py
@@ -160,7 +160,7 @@ def test_file_autocomplete(run_autocomplete: _RunAC, tmp_path: Path) -> None:
 
 @skip_on_windows
 def test_file_autocomplete_default(run_autocomplete: _RunAC) -> None:
-    default = Path.cwd().parent
+    default = Path.cwd()
     default_uri = default.as_uri()
     default_prefix = default_uri[5:]
     names = [p.name + ("/" if p.is_dir() else "") for p in default.iterdir()]
@@ -181,12 +181,12 @@ def test_file_autocomplete_default(run_autocomplete: _RunAC) -> None:
 def test_file_autocomplete_root(run_autocomplete: _RunAC) -> None:
     names = [p.name + ("/" if p.is_dir() else "") for p in Path("/").iterdir()]
     zsh_out, bash_out = run_autocomplete(["storage", "cp", "file:/"])
-    assert bash_out == "\n".join(f"uri,{name},////" for name in names)
-    assert zsh_out == "\n".join(f"uri\n{name}\n_\nfile:////" for name in names)
+    assert bash_out == "\n".join(f"uri,{name},///" for name in names)
+    assert zsh_out == "\n".join(f"uri\n{name}\n_\nfile:///" for name in names)
 
     zsh_out, bash_out = run_autocomplete(["storage", "cp", "file:///"])
-    assert bash_out == "\n".join(f"uri,{name},////" for name in names)
-    assert zsh_out == "\n".join(f"uri\n{name}\n_\nfile:////" for name in names)
+    assert bash_out == "\n".join(f"uri,{name},///" for name in names)
+    assert zsh_out == "\n".join(f"uri\n{name}\n_\nfile:///" for name in names)
 
 
 @skip_on_windows
@@ -198,8 +198,8 @@ def test_storage_autocomplete(run_autocomplete: _RunAC) -> None:
         tree = {
             URL("storage://default"): ["test-user", "other-user"],
             URL("storage://default/test-user"): ["folder", "file.txt"],
-            URL("storage://default/test-user/folder/"): ["folder2", "file2.txt"],
-            URL("storage://default/other-user/"): ["folder3", "file3.txt"],
+            URL("storage://default/test-user/folder"): ["folder2", "file2.txt"],
+            URL("storage://default/other-user"): ["folder3", "file3.txt"],
             URL("storage://other-cluster"): ["test-user"],
         }
 
@@ -261,24 +261,45 @@ def test_storage_autocomplete(run_autocomplete: _RunAC) -> None:
         assert zsh_out == "uri\nfile2.txt\n_\nstorage:folder/"
 
         zsh_out, bash_out = run_autocomplete(["storage", "cp", "storage:/"])
-        assert bash_out == ""
-        assert zsh_out == ""
+        assert bash_out == ("uri,test-user/,//default/\n" "uri,other-user/,//default/")
+        assert zsh_out == (
+            "uri\ntest-user/\n_\nstorage://default/\n"
+            "uri\nother-user/\n_\nstorage://default/"
+        )
+
+        zsh_out, bash_out = run_autocomplete(["storage", "cp", "storage:/t"])
+        assert bash_out == "uri,test-user/,//default/"
+        assert zsh_out == "uri\ntest-user/\n_\nstorage://default/"
 
         zsh_out, bash_out = run_autocomplete(["storage", "cp", "storage:/test-user/"])
-        assert bash_out == ""
-        assert zsh_out == ""
+        assert bash_out == (
+            "uri,folder/,//default/test-user/\n" "uri,file.txt,//default/test-user/"
+        )
+        assert zsh_out == (
+            "uri\nfolder/\n_\nstorage://default/test-user/\n"
+            "uri\nfile.txt\n_\nstorage://default/test-user/"
+        )
 
         zsh_out, bash_out = run_autocomplete(["storage", "cp", "storage://"])
-        assert bash_out == ""
-        assert zsh_out == ""
+        assert bash_out == "uri,default/,//\nuri,other/,//"
+        assert zsh_out == (
+            "uri\ndefault/\n_\nstorage://\n" "uri\nother/\n_\nstorage://"
+        )
 
         zsh_out, bash_out = run_autocomplete(["storage", "cp", "storage://d"])
         assert bash_out == "uri,default/,//"
         assert zsh_out == "uri\ndefault/\n_\nstorage://"
 
         zsh_out, bash_out = run_autocomplete(["storage", "cp", "storage://default/"])
-        assert bash_out == ""
-        assert zsh_out == ""
+        assert bash_out == ("uri,test-user/,//default/\n" "uri,other-user/,//default/")
+        assert zsh_out == (
+            "uri\ntest-user/\n_\nstorage://default/\n"
+            "uri\nother-user/\n_\nstorage://default/"
+        )
+
+        zsh_out, bash_out = run_autocomplete(["storage", "cp", "storage://default/t"])
+        assert bash_out == "uri,test-user/,//default/"
+        assert zsh_out == "uri\ntest-user/\n_\nstorage://default/"
 
 
 @skip_on_windows


### PR DESCRIPTION
* Fix completion of "file:", "file:/", "file://" and "file:///".
* Fix completion of cluster name and user name for storage: scheme.

Closes #2584.