### PR TITLE
Show simple characters in web shell

### DIFF
--- a/neuro-cli/src/neuro_cli/formatters/config.py
+++ b/neuro-cli/src/neuro_cli/formatters/config.py
@@ -1,4 +1,5 @@
 import operator
+import os
 from decimal import Decimal
 from typing import Iterable, List, Mapping, Optional, Union
 
@@ -100,6 +101,13 @@ class ClustersFormatter:
         return RichGroup(*out)
 
 
+def _checkmark_character(value: bool) -> str:
+    if os.getenv("NEURO_EVENT_CATEGORY", "") == "WEB-CLI":
+        return "√" if value else "×"
+    else:
+        return "+" if value else "-"
+
+
 def _format_presets(
     presets: Mapping[str, Preset],
     available_jobs_counts: Optional[Mapping[str, int]],
@@ -136,8 +144,8 @@ def _format_presets(
             name,
             str(preset.cpu),
             format_size(preset.memory_mb * 1024**2),
-            "√" if preset.scheduler_enabled else "×",
-            "√" if preset.preemptible_node else "×",
+            _checkmark_character(preset.scheduler_enabled),
+            _checkmark_character(preset.preemptible_node),
             gpu,
         ]
         if has_tpu:

--- a/neuro-cli/src/neuro_cli/formatters/config.py
+++ b/neuro-cli/src/neuro_cli/formatters/config.py
@@ -103,9 +103,9 @@ class ClustersFormatter:
 
 def _checkmark_character(value: bool) -> str:
     if os.getenv("NEURO_EVENT_CATEGORY", "") == "WEB-CLI":
-        return "√" if value else "×"
-    else:
         return "+" if value else "-"
+    else:
+        return "√" if value else "×"
 
 
 def _format_presets(


### PR DESCRIPTION
Closes https://github.com/neuro-inc/platform-pipelines/issues/300

My investigation showed that the issue with the `√`  and `×` characters lies somewhere deep in the linux configuration and handling of unicode characters. It's not about fonts, it's about multibyte strings. When I run the exact same docker container locally, all symbols work, because my terminal can handle all chars. When I attach to the platform job with web-shell and run separate bash shell - i see the same issues with the characters as in the web, so it's not about web, `ttyd` (the tool we use to expose the shell to the web) or the browser. I also tried different values for the `TERM` env var (`screen`, `xterm`, `xterm-256color`) and none of them helped. 

I suggest this PR as a reasonable workaround: we check whether the CLI is run in the web shell and if so, we replace these characters with `+` and `-` respectively.

Example output:

```
User Configuration:                                       
 User Name            alexeynaiden                        
 Current Cluster      default                             
 Current Org          <no-org>                            
 Credits Quota        unlimited                           
 Jobs Quota           unlimited                           
 API URL              https://staging.neu.ro/api/v1       
 Docker Registry URL  https://registry.default.org.neu.ro 
Resource Presets:                                                                                                          
 Name               #CPU   Memory   Round Robin   Preemptible Node   GPU                     Jobs Avail   Credits per hour 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 cpu-small             1     4.0G        -               -                                           16   1                
 cpu-medium            3    11.0G        -               -                                            1   2                
 cpu-large             7    28.0G        -               -                                            0   4                
 gpu-k80-small         3    57.0G        -               -           1 x nvidia-tesla-k80            30   10               
 gpu-k80-small-p       3    57.0G        -               +           1 x nvidia-tesla-k80            10   1                
 gpu-v100-small        7    57.0G        -               -           1 x nvidia-tesla-v100           10   32               
 gpu-v100-small-p      7    57.0G        -               +           1 x nvidia-tesla-v100           10   4                
 gpu-small             3    57.0G        -               -           1 x nvidia-tesla-k80            30   10               
 gpu-small-p           3    57.0G        -               +           1 x nvidia-tesla-k80            10   1                
 gpu-v100-large       63   480.0G        -               -           8 x nvidia-tesla-v100            4   256              
 gpu-v100-large-p     63   480.0G        -               +           8 x nvidia-tesla-v100            4   32               
 gpu-v100-2           15   115.0M        -               -           2 x nvidia-tesla-v100           16   64               
 gpu-v100-4           31   235.0M        -               -           4 x nvidia-tesla-v100            8   128              
 gpu-v100-8           63   480.0M        -               -           8 x nvidia-tesla-v100            4   256              
```