### PR TITLE
Displaay some additional information for imported buckets

### DIFF
--- a/CHANGELOG.D/2706.feature
+++ b/CHANGELOG.D/2706.feature
@@ -1,0 +1,6 @@
+`neuro blob statbucket` now displays some additional information
+for imported buckets.
+
+* For AWS: "External name", "External endpoint", "External region name".
+* For Azure: "External name", "External endpoint".
+* For GCP: "External name".

--- a/neuro-cli/src/neuro_cli/blob_storage.py
+++ b/neuro-cli/src/neuro_cli/blob_storage.py
@@ -352,6 +352,13 @@ async def statbucket(
     bucket_obj = await root.client.buckets.get(
         bucket, cluster_name=cluster, bucket_owner=owner
     )
+    if bucket_obj.imported:
+        bc = await root.client.buckets.request_tmp_credentials(
+            bucket, cluster_name=cluster, bucket_owner=owner
+        )
+        credentials = bc.credentials
+    else:
+        credentials = None
     if full_uri:
         uri_fmtr: URIFormatter = str
     else:
@@ -364,7 +371,7 @@ async def statbucket(
         uri_fmtr, datetime_formatter=get_datetime_formatter(root.iso_datetime_format)
     )
     with root.pager():
-        root.print(bucket_fmtr(bucket_obj))
+        root.print(bucket_fmtr(bucket_obj, credentials))
 
 
 @command()

--- a/neuro-cli/src/neuro_cli/formatters/buckets.py
+++ b/neuro-cli/src/neuro_cli/formatters/buckets.py
@@ -1,6 +1,6 @@
 import abc
 import operator
-from typing import Sequence
+from typing import Mapping, Optional, Sequence
 
 from rich import box
 from rich.console import Group as RichGroup
@@ -77,7 +77,9 @@ class BucketFormatter:
         self._datetime_formatter = datetime_formatter
         self._uri_formatter = uri_formatter
 
-    def __call__(self, bucket: Bucket) -> RenderableType:
+    def __call__(
+        self, bucket: Bucket, credentials: Optional[Mapping[str, str]] = None
+    ) -> RenderableType:
         table = Table(
             box=None,
             show_header=False,
@@ -94,4 +96,13 @@ class BucketFormatter:
         table.add_row("Provider", bucket.provider)
         table.add_row("Imported", str(bucket.imported))
         table.add_row("Public", str(bucket.public))
+        if credentials is not None:
+            for key, title in [
+                ("bucket_name", "External name"),
+                ("storage_endpoint", "External endpoint"),
+                ("endpoint_url", "External endpoint"),
+                ("region_name", "External region name"),
+            ]:
+                if key in credentials:
+                    table.add_row(title, credentials[key])
         return table


### PR DESCRIPTION
`neuro blob statbucket` now displays some non-secret credential
information for imported buckets.

For AWS: "External name", "External endpoint", "External region name".
For Azure: "External name", "External endpoint".
For GCP: "External name".

Closes #2706.