### PR TITLE
Use only documented humanize feature in format_datetime_human()

### DIFF
--- a/neuro-cli/src/neuro_cli/formatters/utils.py
+++ b/neuro-cli/src/neuro_cli/formatters/utils.py
@@ -115,7 +115,7 @@ def format_datetime_human(
                 humanize.precisedelta(delta, minimum_unit=min_unit, format="%0.0f")
                 + " ago"
             )
-        return humanize.naturaltime(delta)
+        return humanize.naturaldelta(delta) + " ago"
     else:
         when_local = when.astimezone(timezone)
         result = humanize.naturaldate(when_local)


### PR DESCRIPTION
It is not documented, but humanize.naturaltime() accepts a timedelta.
Now type annotations have been added, and MyPy started to complain.