### PR TITLE
Fix test_e2e_restart_failing

### DIFF
--- a/neuro-cli/tests/e2e/test_e2e_jobs.py
+++ b/neuro-cli/tests/e2e/test_e2e_jobs.py
@@ -1022,16 +1022,14 @@ def test_e2e_job_top_format(helper: Helper) -> None:
 @pytest.mark.e2e
 def test_e2e_restart_failing(request: Any, helper: Helper) -> None:
     now = time()
-    exit_after = now + 3600
-    cmd = ";".join(
-        f"""
-          if [[ `date +%s` -gt {exit_after} ]]
-          then
-            echo test_e2e_restart_failing
+    exit_after = int(now + 5 * 60)
+    cmd = f"""
+        if [[ `date +%s` -lt {exit_after} ]]
+        then echo test_e2e_restart_failing
             false
-          fi
-    """.strip().splitlines()
-    )
+        fi
+        """
+    cmd = "; ".join(line.strip() for line in cmd.strip().splitlines())
 
     captured = helper.run_cli_run_job(
         [


### PR DESCRIPTION
There were several errors in the running script. Its goal was first
failures, and after a time passed - success.

* Newline characters were replaced with a semicolon. But the one after
  "then" was a syntax error. The script always failed.
* The termination timestamp was a float. Numerical comparison in Bash only
  works with integers. It was always error.
* Wrong comparison operator. It should be -lt instead of -gt. After
  fixing the above two bugs the script would do an opposite to the
  intention.