### PR TITLE
Re-attach to restarted jobs

### DIFF
--- a/CHANGELOG.D/2802.feature
+++ b/CHANGELOG.D/2802.feature
@@ -1,0 +1,1 @@
+Commands `neuro run` and `neuro attach` now re-attach to restarted jobs. Previously they waited until the job finished.

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobStopProgress.test_no_tty_restart_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobStopProgress.test_no_tty_restart_0.ref
@@ -1,0 +1,2 @@
+Wait for stopping
+Job restarted

--- a/neuro-cli/tests/unit/formatters/ascii/TestJobStopProgress.test_tty_restart_0.ref
+++ b/neuro-cli/tests/unit/formatters/ascii/TestJobStopProgress.test_tty_restart_0.ref
@@ -1,0 +1,1 @@
+- Wait for stop d [2.0 sec]- Wait for stop q [4.0 sec]- Wait for restart p [6.0 sec]- Wait for restart b [8.0 sec]√ Job test-job restarted

--- a/neuro-cli/tests/unit/formatters/test_jobs_formatters.py
+++ b/neuro-cli/tests/unit/formatters/test_jobs_formatters.py
@@ -148,7 +148,7 @@ def job_descr() -> JobDescription:
 
 def make_job(
     status: JobStatus,
-    reason: Optional[str],
+    reason: str,
     *,
     name: Optional[str] = None,
     life_span: Optional[float] = None,
@@ -372,11 +372,11 @@ class TestJobStopProgress:
     def test_no_tty_restart(self, rich_cmp: Any, new_console: _NewConsole) -> None:
         console = new_console(tty=False, color=True)
         with JobStopProgress.create(console, quiet=False) as progress:
-            progress.step(make_job(JobStatus.RUNNING, None, restarts=1))
-            progress.step(make_job(JobStatus.RUNNING, None, restarts=1))
+            progress.step(make_job(JobStatus.RUNNING, "", restarts=1))
+            progress.step(make_job(JobStatus.RUNNING, "", restarts=1))
             progress.step(make_job(JobStatus.RUNNING, "Restarting", restarts=2))
             progress.step(make_job(JobStatus.RUNNING, "Restarting", restarts=2))
-            progress.end(make_job(JobStatus.RUNNING, None, restarts=2))
+            progress.end(make_job(JobStatus.RUNNING, "", restarts=2))
             rich_cmp(console)
 
     def test_tty_restart(
@@ -390,11 +390,11 @@ class TestJobStopProgress:
         )
         console = new_console(tty=True, color=True)
         with JobStopProgress.create(console, quiet=False) as progress:
-            progress.step(make_job(JobStatus.RUNNING, None, restarts=1))
-            progress.step(make_job(JobStatus.RUNNING, None, restarts=1))
+            progress.step(make_job(JobStatus.RUNNING, "", restarts=1))
+            progress.step(make_job(JobStatus.RUNNING, "", restarts=1))
             progress.step(make_job(JobStatus.RUNNING, "Restarting", restarts=2))
             progress.step(make_job(JobStatus.RUNNING, "Restarting", restarts=2))
-            progress.end(make_job(JobStatus.RUNNING, None, restarts=2))
+            progress.end(make_job(JobStatus.RUNNING, "", restarts=2))
             rich_cmp(console)
 
 


### PR DESCRIPTION
Previously "neuro run" and "neuro attach" waited until the job finished
if it restarted.

Closes #2802.