### PR TITLE
fix: Use proper tls client config in neuro-sdk

### DIFF
--- a/neuro-sdk/src/neuro_sdk/_config_factory.py
+++ b/neuro-sdk/src/neuro_sdk/_config_factory.py
@@ -53,7 +53,7 @@ async def __make_session(
 ) -> aiohttp.ClientSession:
     from . import __version__
 
-    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     ssl_context.load_verify_locations(capath=certifi.where())
     connector = aiohttp.TCPConnector(ssl=ssl_context)
     return aiohttp.ClientSession(


### PR DESCRIPTION
This caused a deprecation warning in 3.10, which messes up tests, e.g. `platform-monioring`