### PR TITLE
Install async-timeout explicitly

### DIFF
--- a/neuro-cli/setup.cfg
+++ b/neuro-cli/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     prompt-toolkit>=3.0.13
     rich>=11.0.0
     jedi>=0.16
+    async-timeout>=4.0.0 ; python_version < "3.11"
 
 [options.entry_points]
 console_scripts =

--- a/neuro-cli/src/neuro_cli/job.py
+++ b/neuro-cli/src/neuro_cli/job.py
@@ -9,10 +9,14 @@ from contextlib import AsyncExitStack
 from datetime import datetime, timedelta, timezone
 from typing import AsyncIterator, List, Optional, Sequence, Set, Tuple
 
-import async_timeout
 import click
 from dateutil.parser import isoparse
 from yarl import URL
+
+if sys.version_info >= (3, 11):
+    import asyncio as async_timeout
+else:
+    import async_timeout
 
 from neuro_sdk import (
     PASS_CONFIG_ENV_NAME,


### PR DESCRIPTION
`async-timeout` is an implicit dependency we have from https://github.com/aio-libs/aiohttp.

Recently, aiohttp replaced async-timeout with built-in into asyncio [asyncio.timeout](https://docs.python.org/3/library/asyncio-task.html#asyncio.timeout) (added in python 3.11).

So all our new installation on python 3.11 did not have this dependency.

Here we install it as a dependency explicitly for python < 3.11